### PR TITLE
transitiveJarDependencies option

### DIFF
--- a/src/main/java/org/deegree/maven/WorkspaceMojo.java
+++ b/src/main/java/org/deegree/maven/WorkspaceMojo.java
@@ -102,6 +102,12 @@ public class WorkspaceMojo extends AbstractMojo {
      * @parameter expression="${localRepository}"
      */
     private ArtifactRepository localRepository;
+    
+    /**
+     * 
+     * @parameter default-value="false"
+     */
+    private boolean transitiveJarDependencies;
 
 
     @Override
@@ -120,7 +126,7 @@ public class WorkspaceMojo extends AbstractMojo {
             reverse( workspaces );
 
             Set<?> jarDeps = getDependencyArtifacts( project, artifactResolver, artifactFactory, metadataSource,
-                                                     localRepository, "jar", false );
+                                                     localRepository, "jar", transitiveJarDependencies );
 
             File target = new File( project.getBasedir(), "target" );
             if ( !target.exists() && !target.mkdirs() ) {


### PR DESCRIPTION
Pull requests to add a transitiveJarDependencies option.

For some projects it is desirable to have transitive dependency resolving enabled for deegree-workspace modules. 
