### PR TITLE
Bumped dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target
 .classpath
 .project
 .settings
+.idea
+pom.xml.versionsBackup
+*iml

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>deegree-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.21-SNAPSHOT</version>
+  <version>2.0.0-beta1-SNAPSHOT</version>
   <name>deegree-maven-plugin</name>
   <description>Maven plugin for tasks related to building deegree</description>
 
@@ -15,9 +15,13 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.2.2</version>
+    <version>3.4-pre23</version>
     <relativePath />
   </parent>
+
+  <properties>
+    <java.version>1.8</java.version>
+  </properties>
 
   <repositories>
     <repository>
@@ -54,6 +58,11 @@
            <goals>deploy</goals>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.5.1</version>
+      </plugin>
     </plugins>
   </build>
 
@@ -61,49 +70,56 @@
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-api</artifactId>
-      <version>2.0.8</version>
+      <version>3.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-impl</artifactId>
-      <version>2.0.4.3</version>
+      <version>3.0.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>2.0.1</version>
+      <version>3.1.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
-      <version>2.2.1</version>
+      <version>3.0-alpha-2</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>2.2.1</version>
+      <version>3.5.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.5.1</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.2.1</version>
+      <version>3.5.3</version>
     </dependency>
 
     <dependency>
       <groupId>org.deegree</groupId>
       <artifactId>deegree-core-base</artifactId>
-      <version>3.2.2</version>
+      <version>3.4-pre23</version>
     </dependency>
 
     <dependency>
       <groupId>org.deegree</groupId>
       <artifactId>deegree-protocol-wms</artifactId>
-      <version>3.2.2</version>
+      <version>3.4-pre23</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,21 @@
         <artifactId>maven-plugin-plugin</artifactId>
         <version>3.5.1</version>
       </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+              <configuration>
+              <doclint>none</doclint>
+          </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/org/deegree/maven/BuildnumberMojo.java
+++ b/src/main/java/org/deegree/maven/BuildnumberMojo.java
@@ -46,29 +46,30 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
- * @goal generate-buildinfo
- * @phase generate-resources
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
  * 
  * @version $Revision$, $Date$
  */
+@Execute(goal = "generate-buildinfo", phase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "generate-buildinfo")
 public class BuildnumberMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     @Override
     public void execute()
-                            throws MojoExecutionException, MojoFailureException {
+                            throws MojoExecutionException,
+                            MojoFailureException {
         Log log = getLog();
         Properties ps = new Properties();
         ps.put( "build.artifactId", project.getArtifactId() );

--- a/src/main/java/org/deegree/maven/ConsoleMojo.java
+++ b/src/main/java/org/deegree/maven/ConsoleMojo.java
@@ -42,67 +42,50 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.RepositorySystem;
 import org.reflections.Reflections;
 import org.reflections.serializers.Serializer;
 
 import com.google.common.base.Predicate;
 
 /**
- * @goal assemble-console
- * @phase generate-resources
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
  * 
  * @version $Revision$, $Date$
  */
+@Execute(goal = "assemble-console", phase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "assemble-console")
 public class ConsoleMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
-    /**
-     * @component
-     */
+    @Component
     private ArtifactResolver artifactResolver;
 
-    /**
-     * 
-     * @component
-     */
-    private ArtifactFactory artifactFactory;
+    @Component
+    private RepositorySystem repositorySystem;
 
-    /**
-     * 
-     * @component
-     */
-    private ArtifactMetadataSource metadataSource;
-
-    /**
-     * 
-     * @parameter expression="${localRepository}"
-     */
+    @Parameter(property = "localRepository")
     private ArtifactRepository localRepository;
 
     String input;
 
     @Override
     public void execute()
-                            throws MojoExecutionException, MojoFailureException {
+                            throws MojoExecutionException,
+                            MojoFailureException {
 
-        addDependenciesToClasspath( project, artifactResolver, artifactFactory, metadataSource, localRepository );
+        addDependenciesToClasspath( project, artifactResolver, repositorySystem, localRepository );
 
         final File dir = new File( project.getBasedir(), "src/main/webapp/console" );
         if ( !dir.isDirectory() && !dir.mkdirs() ) {

--- a/src/main/java/org/deegree/maven/CopyMojo.java
+++ b/src/main/java/org/deegree/maven/CopyMojo.java
@@ -44,24 +44,24 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
- * @goal copy
- * @phase generate-resources
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
  * 
  * @version $Revision$, $Date$
  */
+@Execute(goal = "copy", phase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "copy")
 public class CopyMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}")
     private MavenProject project;
 
     /**
@@ -71,7 +71,8 @@ public class CopyMojo extends AbstractMojo {
 
     @Override
     public void execute()
-                            throws MojoExecutionException, MojoFailureException {
+                            throws MojoExecutionException,
+                            MojoFailureException {
         Log log = getLog();
         if ( files == null ) {
             log.debug( "No files configured." );

--- a/src/main/java/org/deegree/maven/EclipseMojo.java
+++ b/src/main/java/org/deegree/maven/EclipseMojo.java
@@ -35,36 +35,30 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.maven;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.Properties;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
- * @goal eclipse
- * 
+ *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author: aschmitz $
  * 
  * @version $Revision: 31419 $, $Date: 2011-08-02 17:42:17 +0200 (Di, 02. Aug 2011) $
  */
+@Execute(goal = "eclipse")
+@Mojo(name = "eclipse")
 public class EclipseMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     @Override

--- a/src/main/java/org/deegree/maven/EclipseProjectLinker.java
+++ b/src/main/java/org/deegree/maven/EclipseProjectLinker.java
@@ -35,40 +35,36 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.maven;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.Properties;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
- * @goal create-links
- * 
+ *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author$
  * 
  * @version $Revision$, $Date$
  */
+@Execute(goal = "create-links")
+@Mojo(name = "create-links")
 public class EclipseProjectLinker extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     @Override
     public void execute()
-                            throws MojoExecutionException, MojoFailureException {
+                            throws MojoExecutionException,
+                            MojoFailureException {
 
         String eclipseWorkspace = System.getProperty( "eclipse.workspace" );
         String formatter = System.getProperty( "eclipse.formatter" );

--- a/src/main/java/org/deegree/maven/EclipseWorkingSetMojo.java
+++ b/src/main/java/org/deegree/maven/EclipseWorkingSetMojo.java
@@ -39,12 +39,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -59,6 +54,9 @@ import javax.xml.transform.stream.StreamResult;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -69,22 +67,16 @@ import org.xml.sax.SAXException;
 /**
  * Mojo to automatically setup deegree working sets and to move projects into working sets.
  * 
- * @goal setup-eclipse-working-sets
- * @aggregator
- * @requiresDirectInvocation
- * 
  * @author <a href="mailto:schmitz@occamlabs.de">Andreas Schmitz</a>
  * @author last edited by: $Author: stranger $
  * 
  * @version $Revision: $, $Date: $
  */
+@Execute(goal = "setup-eclipse-working-sets")
+@Mojo(name = "setup-eclipse-working-sets", aggregator = true, requiresDirectInvocation = true)
 public class EclipseWorkingSetMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     private int counter = 0;

--- a/src/main/java/org/deegree/maven/Log4jMojo.java
+++ b/src/main/java/org/deegree/maven/Log4jMojo.java
@@ -118,7 +118,7 @@ public class Log4jMojo extends AbstractMojo {
         out.println();
     }
 
-    private void collect( final String type, String msg, final PrintWriter out ) {
+    private void collect( final String type, String msg, final PrintWriter out, final String version ) {
         block( msg, out );
 
         // seems to scan automatically without requesting something
@@ -144,7 +144,7 @@ public class Log4jMojo extends AbstractMojo {
 
             @Override
             public boolean acceptsInput( String file ) {
-                return file.equals( "META-INF.deegree.log4j." + type.toLowerCase() );
+                return file.equals( "META-INF.deegree.log4j-" + version + "." + type.toLowerCase() );
             }
 
             @Override
@@ -182,6 +182,7 @@ public class Log4jMojo extends AbstractMojo {
             getLog().info( "Skipping generation of log4j2.xml as it already exists in src/main/resources." );
             return;
         }
+        String version = project.getVersion();
 
         addDependenciesToClasspath( project, artifactResolver, repositorySystem, localRepository );
 
@@ -225,11 +226,11 @@ public class Log4jMojo extends AbstractMojo {
 
             o = out;
 
-            collect( "ERROR", "Severe error messages", out );
-            collect( "WARN", "Important warning messages", out );
-            collect( "INFO", "Informational messages", out );
-            collect( "DEBUG", "Debugging messages, useful for in-depth debugging of e.g. service setups", out );
-            collect( "TRACE", "Tracing messages, for developers only", out );
+            collect( "ERROR", "Severe error messages", out, version );
+            collect( "WARN", "Important warning messages", out, version );
+            collect( "INFO", "Informational messages", out, version );
+            collect( "DEBUG", "Debugging messages, useful for in-depth debugging of e.g. service setups", out, version );
+            collect( "TRACE", "Tracing messages, for developers only", out, version );
 
             out.println( "    <AsyncRoot level=\"" + rootLoggingLevel + "\">" );
             out.println( "      <AppenderRef ref=\"stdout\" />" );

--- a/src/main/java/org/deegree/maven/Log4jMojo.java
+++ b/src/main/java/org/deegree/maven/Log4jMojo.java
@@ -36,99 +36,72 @@
 package org.deegree.maven;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
-import static org.apache.commons.io.IOUtils.copy;
+import static org.apache.log4j.LogManager.getLogger;
 import static org.deegree.maven.utils.ClasspathHelper.addDependenciesToClasspath;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.log4j.Logger;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.RepositorySystem;
+import org.reflections.Configuration;
 import org.reflections.Reflections;
-import org.reflections.serializers.Serializer;
+import org.reflections.scanners.AbstractScanner;
+import org.reflections.scanners.Scanner;
+import org.reflections.vfs.Vfs;
 
 import com.google.common.base.Predicate;
+import com.google.common.collect.Multimap;
 
 /**
- * @goal assemble-log4j
- * @phase generate-resources
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
- * 
+ *
  * @version $Revision$, $Date$
  */
+@Execute(goal = "assemble-log4j", phase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "assemble-log4j")
 public class Log4jMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="120"
-     * @required
-     */
+    private static Logger LOG = getLogger( Log4jMojo.class );
+
+    @Parameter(defaultValue = "120", required = true)
     private int width;
 
-    /**
-     * @parameter default-value="INFO"
-     * @required
-     */
+    @Parameter(defaultValue = "INFO", required = true)
     private String deegreeLoggingLevel;
 
-    /**
-     * @parameter default-value="ERROR"
-     * @required
-     */
+    @Parameter(defaultValue = "ERROR", required = true)
     private String rootLoggingLevel;
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
-    /**
-     * @component
-     */
+    @Component
     private ArtifactResolver artifactResolver;
 
-    /**
-     * 
-     * @component
-     */
-    private ArtifactFactory artifactFactory;
+    @Component
+    private RepositorySystem repositorySystem;
 
-    /**
-     * 
-     * @component
-     */
-    private ArtifactMetadataSource metadataSource;
-
-    /**
-     * 
-     * @parameter expression="${localRepository}"
-     */
+    @Parameter(property = "localRepository")
     private ArtifactRepository localRepository;
 
     private void block( String text, PrintWriter out ) {
-        out.print( "# " );
+        out.print( "<!-- " );
         for ( int i = 0; i < width - 2; ++i ) {
             out.print( "=" );
         }
-        out.println();
+        out.println( " -->" );
         int odd = text.length() % 2;
         int len = ( width - text.length() - 4 ) / 2;
-        out.print( "# " );
+        out.print( "<!-- " );
         for ( int i = 0; i < len; ++i ) {
             out.print( "=" );
         }
@@ -136,104 +109,135 @@ public class Log4jMojo extends AbstractMojo {
         for ( int i = 0; i < len + odd; ++i ) {
             out.print( "=" );
         }
-        out.println();
-        out.print( "# " );
+        out.println( " -->" );
+        out.print( "<!-- " );
         for ( int i = 0; i < width - 2; ++i ) {
             out.print( "=" );
         }
-        out.println();
+        out.println( " -->" );
         out.println();
     }
 
-    private void collect( final Reflections r, final String type, String msg, final PrintWriter out ) {
+    private void collect( final String type, String msg, final PrintWriter out ) {
         block( msg, out );
-        r.collect( "META-INF/deegree/log4j", new Predicate<String>() {
+
+        // seems to scan automatically without requesting something
+        new Reflections( "META-INF.deegree", new AbstractScanner() {
+
             @Override
-            public boolean apply( String input ) {
-                return input != null && input.equals( type );
+            public void setConfiguration( Configuration configuration ) {
             }
-        }, new Serializer() {
+
             @Override
-            public Reflections read( InputStream in ) {
+            public Multimap<String, String> getStore() {
+                return null;
+            }
+
+            @Override
+            public void setStore( Multimap<String, String> store ) {
+            }
+
+            @Override
+            public Scanner filterResultsBy( Predicate<String> filter ) {
+                return null;
+            }
+
+            @Override
+            public boolean acceptsInput( String file ) {
+                return file.equals( "META-INF.deegree.log4j." + type.toLowerCase() );
+            }
+
+            @Override
+            public void scan( Vfs.File file ) {
                 try {
-                    copy( in, out );
+                    InputStream in = file.openInputStream();
+                    BufferedReader reader = new BufferedReader( new InputStreamReader( in, "UTF-8" ) );
+                    String line;
+                    while ( ( line = reader.readLine() ) != null ) {
+                        out.println( line );
+                    }
                 } catch ( IOException e ) {
-                    getLog().error( e );
+                    LOG.error( "Trouble extracting the log4j snippet: " + e.getMessage() );
+                    LOG.error( "This shouldn't happen, set log level to debug to see the stack trace." );
+                    LOG.debug( e.getMessage(), e );
                 }
-                return r;
             }
 
             @Override
-            public File save( Reflections reflections, String filename ) {
-                return null;
+            public void scan( Object cls ) {
             }
 
             @Override
-            public String toString( Reflections reflections ) {
-                return null;
+            public boolean acceptResult( String fqn ) {
+                return fqn.equals( "META-INF.deegree.log4j." + type.toLowerCase() );
             }
         } );
     }
 
     @Override
     public void execute()
-                            throws MojoExecutionException, MojoFailureException {
-        if ( new File( project.getBasedir(), "src/main/resources/log4j.properties" ).exists() ) {
-            getLog().info( "Skipping generation of log4j.properties as it already exists in src/main/resources." );
+                            throws MojoExecutionException,
+                            MojoFailureException {
+        if ( new File( project.getBasedir(), "src/main/resources/log4j2.xml" ).exists() ) {
+            getLog().info( "Skipping generation of log4j2.xml as it already exists in src/main/resources." );
             return;
         }
 
-        addDependenciesToClasspath( project, artifactResolver, artifactFactory, metadataSource, localRepository );
+        addDependenciesToClasspath( project, artifactResolver, repositorySystem, localRepository );
 
-        final Reflections r = new Reflections( "/META-INF/deegree" );
         // to work around stupid initialization compiler error (hey, it's defined to be null if not 'initialized'!)
         PrintWriter o = null;
         final PrintWriter out;
         try {
-            File outFile = new File( project.getBasedir(), "target/generated-resources/log4j.properties" );
+            File outFile = new File( project.getBasedir(), "target/generated-resources/log4j2.xml" );
             if ( !outFile.getParentFile().exists() && !outFile.getParentFile().mkdirs() ) {
                 throw new MojoFailureException( "Could not create parent directory: " + outFile.getParentFile() );
             }
             out = new PrintWriter( new OutputStreamWriter( new FileOutputStream( outFile ), "UTF-8" ) );
 
-            out.println( "# by default, only log to stdout" );
-            out.println( "log4j.rootLogger=" + rootLoggingLevel + ", stdout" );
-            out.println( "log4j.appender.stdout=org.apache.log4j.ConsoleAppender" );
-            out.println( "log4j.appender.stdout.layout=org.apache.log4j.PatternLayout" );
-            out.println( "log4j.appender.stdout.layout.ConversionPattern=[%d{HH:mm:ss}] %5p: [%c{1}] %m%n" );
-            out.println();
-            out.println( "## example log file appender" );
-            out.println( "## ${context.name} as variable in log file names is NOT supported any more (it breaks more often than not)" );
-            out.println();
-            out.println( "#log.dir=${catalina.base}/logs" );
-            out.println( "#log4j.appender.logfile=org.apache.log4j.RollingFileAppender" );
-            out.println( "#log4j.appender.logfile.File=${log.dir}/example.log" );
-            out.println( "#log4j.appender.logfile.MaxFileSize=1000KB" );
-            out.println( "## Keep one backup file" );
-            out.println( "#log4j.appender.logfile.MaxBackupIndex=1" );
-            out.println( "#log4j.appender.logfile.layout=org.apache.log4j.PatternLayout" );
-            out.println( "#log4j.appender.logfile.layout.ConversionPattern=%d %-5p [%c] %m%n" );
+            out.println( "<!-- by default, only log to stdout -->" );
+            out.println( "<Configuration>" );
+            out.println( "  <Appenders>" );
+            out.println( "    <Console name=\"stdout\" target=\"SYSTEM_OUT\">" );
+            out.println( "      <PatternLayout pattern=\"[%d{HH:mm:ss}] %5p: [%c{1}] %m%n\">" );
+            out.println( "    </Console>" );
+            out.println( "    <!-- example log file appender -->" );
+            out.println( "    <!-- RollingFile name=\"MyFile\" fileName=\"logs/app.log\">" );
+            out.println( "      <PatternLayout pattern=\"[%d{HH:mm:ss}] %5p: [%c{1}] %m%n\">" );
+            out.println( "        <Policies>" );
+            out.println( "          <TimeBasedTriggeringPolicy />" );
+            out.println( "          <SizeBasedTriggeringPolicy size=\"1000KB\" />" );
+            out.println( "        </Policies>" );
+            out.println( "        <DefaultRolloverStrategy />" );
+            out.println( "    </RollingFile -->" );
+            out.println( "  </Appenders>" );
+            out.println( "  <Loggers>" );
             out.println();
 
-            out.println( "# The log level for the org.reflections package (to avoid superfluous messages)." );
-            out.println( "log4j.logger.org.reflections = FATAL" );
+            out.println( "    <!-- The log level for all classes that are not configured below. -->" );
+            out.println( "    <AsyncLogger name=\"org.reflections\" level=\"FATAL\" />" );
             out.println();
-            out.println( "# The log level for all classes that are not configured below." );
-            out.println( "log4j.logger.org.deegree = " + deegreeLoggingLevel );
+            out.println( "    <!-- The log level for all classes that are not configured below. -->" );
+            out.println( "    <AsyncLogger name=\"org.deegree\" level=\"" + deegreeLoggingLevel + "\" />" );
             out.println();
-            out.println( "# automatically generated output follows" );
+            out.println( "    <!-- automatically generated output follows -->" );
             out.println();
 
             o = out;
 
-            collect( r, "error", "Severe error messages", out );
-            collect( r, "warn", "Important warning messages", out );
-            collect( r, "info", "Informational messages", out );
-            collect( r, "debug", "Debugging messages, useful for in-depth debugging of e.g. service setups", out );
-            collect( r, "trace", "Tracing messages, for developers only", out );
-        } catch ( FileNotFoundException e ) {
-            getLog().error( e );
-        } catch ( UnsupportedEncodingException e ) {
+            collect( "ERROR", "Severe error messages", out );
+            collect( "WARN", "Important warning messages", out );
+            collect( "INFO", "Informational messages", out );
+            collect( "DEBUG", "Debugging messages, useful for in-depth debugging of e.g. service setups", out );
+            collect( "TRACE", "Tracing messages, for developers only", out );
+
+            out.println( "    <AsyncRoot level=\"" + rootLoggingLevel + "\">" );
+            out.println( "      <AppenderRef ref=\"stdout\" />" );
+            out.println( "    </AsyncRoot>" );
+
+            out.println( "  </Loggers>" );
+            out.println( "</Configuration>" );
+        } catch ( IOException e ) {
             getLog().error( e );
         } finally {
             closeQuietly( o );

--- a/src/main/java/org/deegree/maven/ModuleListMojo.java
+++ b/src/main/java/org/deegree/maven/ModuleListMojo.java
@@ -35,39 +35,35 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.maven;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
- * @goal list-modules-wiki
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
  * 
  * @version $Revision$, $Date: 2011-09-13 15:43:38 +0200 (Di, 13. Sep 2011) $
  */
+@Execute(goal = "list-modules-wiki")
+@Mojo(name = "list-modules-wiki")
 public class ModuleListMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     @Override
     public void execute()
-                            throws MojoExecutionException, MojoFailureException {
+                            throws MojoExecutionException,
+                            MojoFailureException {
 
         FileOutputStream fos = null;
         try {

--- a/src/main/java/org/deegree/maven/ModuleListSiteMojo.java
+++ b/src/main/java/org/deegree/maven/ModuleListSiteMojo.java
@@ -38,42 +38,36 @@ package org.deegree.maven;
 import java.util.Locale;
 
 import org.apache.maven.doxia.siterenderer.Renderer;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.MavenReportException;
 
 /**
- * @goal generate-modules-site
- * @aggregator
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
  * @phase site
  * 
  * @version $Revision$, $Date: 2011-09-13 15:43:38 +0200 (Di, 13. Sep 2011) $
  */
+@Execute(goal = "generate-modules-site")
+@Mojo(name = "generate-modules-site", aggregator = true)
 public class ModuleListSiteMojo extends AbstractMavenReport {
 
     /**
      * Directory where reports will go.
-     * 
-     * @parameter expression="${project.reporting.outputDirectory}"
-     * @required  * @readonly  
      */
+    @Parameter(property = "project.reporting.outputDirectory", readonly = true, required = true)
     private String outputDirectory;
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
-    /**
-     * @component
-     * @required
-     * @readonly
-     */
+    @Component
     private Renderer siteRenderer;
 
     @Override

--- a/src/main/java/org/deegree/maven/PortnumberMojo.java
+++ b/src/main/java/org/deegree/maven/PortnumberMojo.java
@@ -37,40 +37,32 @@ package org.deegree.maven;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
+import java.io.*;
 import java.nio.channels.FileLock;
 
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
- * @goal generate-portnumber
- * @phase initialize
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
  * 
  * @version $Revision$, $Date$
  */
+@Execute(goal = "generate-portnumber", phase = LifecyclePhase.INITIALIZE)
+@Mojo(name = "generate-portnumber")
 public class PortnumberMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     @Override
-    public void execute()
-                            throws MojoExecutionException, MojoFailureException {
+    public void execute() {
         PrintStream out = null;
         BufferedReader reader = null;
         FileLock lock = null;

--- a/src/main/java/org/deegree/maven/ServiceIntegrationTestMojo.java
+++ b/src/main/java/org/deegree/maven/ServiceIntegrationTestMojo.java
@@ -40,50 +40,43 @@ import java.io.File;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.deegree.maven.ithelper.ServiceIntegrationTestHelper;
 
 /**
- * @goal test-services
- * @phase integration-test
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
  * 
  * @version $Revision$, $Date$
  */
+@Execute(goal = "test-services", phase = LifecyclePhase.INTEGRATION_TEST)
+@Mojo(name = "test-services")
 public class ServiceIntegrationTestMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
-    /**
-     * @parameter default-value="true"
-     */
+    @Parameter(defaultValue = "true")
     private boolean testCapabilities;
 
-    /**
-     * @parameter default-value="true"
-     */
+    @Parameter(defaultValue = "true")
     private boolean testLayers;
 
-    /**
-     * @parameter default-value="true"
-     */
+    @Parameter(defaultValue = "true")
     private boolean testRequests;
 
-    /**
-     * @parameter default-value="${project.basedir}/src/main/webapp/WEB-INF/workspace"
-     */
+    @Parameter(defaultValue = "${project.basedir}/src/main/webapp/WEB-INF/workspace")
     private File workspace;
 
     @Override
     public void execute()
-                            throws MojoExecutionException, MojoFailureException {
+                            throws MojoExecutionException,
+                            MojoFailureException {
         try {
             if ( !workspace.exists() ) {
                 workspace = new File( project.getBasedir(), "src/main/webapp/WEB-INF/conf" );
@@ -91,7 +84,8 @@ public class ServiceIntegrationTestMojo extends AbstractMojo {
                     getLog().error( "Could not find a workspace to operate on." );
                     throw new MojoFailureException( "Could not find a workspace to operate on." );
                 }
-                getLog().warn( "Default/configured workspace did not exist, using existing " + workspace + " instead." );
+                getLog().warn( "Default/configured workspace did not exist, using existing " + workspace
+                               + " instead." );
             }
 
             ServiceIntegrationTestHelper helper = new ServiceIntegrationTestHelper( project, getLog() );

--- a/src/main/java/org/deegree/maven/WorkspaceITMojo.java
+++ b/src/main/java/org/deegree/maven/WorkspaceITMojo.java
@@ -53,31 +53,32 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.deegree.maven.ithelper.ServiceIntegrationTestHelper;
 import org.deegree.maven.utils.HttpUtils;
 
 /**
- * @goal test-workspaces
- * @phase integration-test
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
  * 
  * @version $Revision$, $Date$
  */
+@Execute(goal = "test-workspaces", phase = LifecyclePhase.INTEGRATION_TEST)
+@Mojo(name = "test-workspaces")
 public class WorkspaceITMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
     @Override
     public void execute()
-                            throws MojoExecutionException, MojoFailureException {
+                            throws MojoExecutionException,
+                            MojoFailureException {
         Set<?> artifacts = project.getDependencyArtifacts();
         Set<Artifact> workspaces = new HashSet<Artifact>();
         for ( Object o : artifacts ) {

--- a/src/main/java/org/deegree/maven/XMLCatalogueMojo.java
+++ b/src/main/java/org/deegree/maven/XMLCatalogueMojo.java
@@ -47,63 +47,46 @@ import java.io.PrintStream;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
 
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.RepositorySystem;
 import org.reflections.Reflections;
 import org.reflections.serializers.Serializer;
 
 import com.google.common.base.Predicate;
 
 /**
- * @goal generate-jaxb-catalog
- * @phase generate-resources
- * 
+ *
  * @author <a href="mailto:schmitz@occamlabs.de">Andreas Schmitz</a>
  * @author last edited by: $Author: aschmitz $
  * 
  * @version $Revision: 31419 $, $Date: 2011-08-02 17:42:17 +0200 (Tue, 02 Aug 2011) $
  */
+@Execute(goal = "generate-jaxb-catalog", phase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "generate-jaxb-catalog")
 public class XMLCatalogueMojo extends AbstractMojo {
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
-    /**
-     * @component
-     */
+    @Component
     private ArtifactResolver artifactResolver;
 
-    /**
-     * 
-     * @component
-     */
-    private ArtifactFactory artifactFactory;
+    @Component
+    private RepositorySystem repositorySystem;
 
-    /**
-     * 
-     * @component
-     */
-    private ArtifactMetadataSource metadataSource;
-
-    /**
-     * 
-     * @parameter expression="${localRepository}"
-     */
+    @Parameter(name = "localRepository")
     private ArtifactRepository localRepository;
 
     @Override
     public void execute()
-                            throws MojoExecutionException, MojoFailureException {
+                            throws MojoExecutionException,
+                            MojoFailureException {
         File target = new File( project.getBasedir(), "target" );
         target.mkdirs();
         target = new File( target, "deegree.xmlcatalog" );
@@ -113,7 +96,7 @@ public class XMLCatalogueMojo extends AbstractMojo {
             catalogOut = new PrintStream( new FileOutputStream( target ), true, "UTF-8" );
             final PrintStream catalog = catalogOut;
 
-            addDependenciesToClasspath( project, artifactResolver, artifactFactory, metadataSource, localRepository );
+            addDependenciesToClasspath( project, artifactResolver, repositorySystem, localRepository );
 
             final XMLInputFactory fac = XMLInputFactory.newInstance();
             final Reflections r = new Reflections( "/META-INF/schemas/" );


### PR DESCRIPTION
I'm preparing to upgrade deegree's dependencies. In order to do that, I'd also need to upgrade the logging dependencies. The deegree maven plugin generates log4j.properties for log4 1 currently. I've upgraded deegree to use log4j2.

In order for the generation of log4j config files to function, we need to

* update the maven plugin to generate a log4j2.xml file
* update the deegree logging annotation processor to generate log4j2.xml conformant snippets

So I've upgraded the maven plugin to the latest dependencies, removed all the deprecations and upgraded the log4jmojo. But before I can do a deegree PR to upgrade dependencies, I'd need the maven plugin upgrade. This PR upgrades the version to 2.0.0-beta1-SNAPSHOT. I'd appreciate someone with access to the nexus to do a release if this is merged.

Please note that my PR upgrading the deegree deps currently pins down ehcache to 2.10.x and doesn't upgrade a few dependencies such as the httpclient (it has undergone a lot of API changes). If I find the time, those will follow later. Once this is merged and released, I can finalize my PR with the deegree upgrades.