### PR TITLE
Add default phase for all phased mojos, fix upgrade bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-impl</artifactId>
       <version>3.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>dom4j</groupId>
+          <artifactId>dom4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.4-pre23</version>
+    <version>3.4.2</version>
     <relativePath />
   </parent>
 
@@ -110,32 +110,44 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.5.3</version>
+      <version>3.5.4</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.5.1</version>
+      <version>3.5.2</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.5.3</version>
+      <version>3.5.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.deegree</groupId>
       <artifactId>deegree-core-base</artifactId>
-      <version>3.4-pre23</version>
+      <version>3.4.2</version>
     </dependency>
 
     <dependency>
       <groupId>org.deegree</groupId>
       <artifactId>deegree-protocol-wms</artifactId>
-      <version>3.4-pre23</version>
+      <version>3.4.2</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/deegree/maven/BuildnumberMojo.java
+++ b/src/main/java/org/deegree/maven/BuildnumberMojo.java
@@ -60,7 +60,7 @@ import org.apache.maven.project.MavenProject;
  * @version $Revision$, $Date$
  */
 @Execute(goal = "generate-buildinfo", phase = LifecyclePhase.GENERATE_RESOURCES)
-@Mojo(name = "generate-buildinfo")
+@Mojo(name = "generate-buildinfo", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public class BuildnumberMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)

--- a/src/main/java/org/deegree/maven/ConsoleMojo.java
+++ b/src/main/java/org/deegree/maven/ConsoleMojo.java
@@ -63,7 +63,7 @@ import com.google.common.base.Predicate;
  * @version $Revision$, $Date$
  */
 @Execute(goal = "assemble-console", phase = LifecyclePhase.GENERATE_RESOURCES)
-@Mojo(name = "assemble-console")
+@Mojo(name = "assemble-console", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public class ConsoleMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)

--- a/src/main/java/org/deegree/maven/ConsoleMojo.java
+++ b/src/main/java/org/deegree/maven/ConsoleMojo.java
@@ -75,7 +75,7 @@ public class ConsoleMojo extends AbstractMojo {
     @Component
     private RepositorySystem repositorySystem;
 
-    @Parameter(property = "localRepository")
+    @Parameter(defaultValue = "${localRepository}")
     private ArtifactRepository localRepository;
 
     String input;

--- a/src/main/java/org/deegree/maven/CopyMojo.java
+++ b/src/main/java/org/deegree/maven/CopyMojo.java
@@ -58,7 +58,7 @@ import org.apache.maven.project.MavenProject;
  * @version $Revision$, $Date$
  */
 @Execute(goal = "copy", phase = LifecyclePhase.GENERATE_RESOURCES)
-@Mojo(name = "copy")
+@Mojo(name = "copy", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public class CopyMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}")

--- a/src/main/java/org/deegree/maven/Log4jMojo.java
+++ b/src/main/java/org/deegree/maven/Log4jMojo.java
@@ -67,7 +67,7 @@ import com.google.common.collect.Multimap;
  * @version $Revision$, $Date$
  */
 @Execute(goal = "assemble-log4j", phase = LifecyclePhase.GENERATE_RESOURCES)
-@Mojo(name = "assemble-log4j")
+@Mojo(name = "assemble-log4j", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public class Log4jMojo extends AbstractMojo {
 
     private static Logger LOG = getLogger( Log4jMojo.class );

--- a/src/main/java/org/deegree/maven/Log4jMojo.java
+++ b/src/main/java/org/deegree/maven/Log4jMojo.java
@@ -41,6 +41,7 @@ import static org.deegree.maven.utils.ClasspathHelper.addDependenciesToClasspath
 
 import java.io.*;
 
+import org.apache.http.protocol.SyncBasicHttpContext;
 import org.apache.log4j.Logger;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
@@ -148,7 +149,7 @@ public class Log4jMojo extends AbstractMojo {
             }
 
             @Override
-            public void scan( Vfs.File file ) {
+            public Object scan( Vfs.File file, Object classObject ) {
                 try {
                     InputStream in = file.openInputStream();
                     BufferedReader reader = new BufferedReader( new InputStreamReader( in, "UTF-8" ) );
@@ -161,6 +162,7 @@ public class Log4jMojo extends AbstractMojo {
                     LOG.error( "This shouldn't happen, set log level to debug to see the stack trace." );
                     LOG.debug( e.getMessage(), e );
                 }
+                return classObject;
             }
 
             @Override

--- a/src/main/java/org/deegree/maven/Log4jMojo.java
+++ b/src/main/java/org/deegree/maven/Log4jMojo.java
@@ -41,7 +41,6 @@ import static org.deegree.maven.utils.ClasspathHelper.addDependenciesToClasspath
 
 import java.io.*;
 
-import org.apache.http.protocol.SyncBasicHttpContext;
 import org.apache.log4j.Logger;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
@@ -91,7 +90,7 @@ public class Log4jMojo extends AbstractMojo {
     @Component
     private RepositorySystem repositorySystem;
 
-    @Parameter(property = "localRepository")
+    @Parameter(defaultValue = "${localRepository}")
     private ArtifactRepository localRepository;
 
     private void block( String text, PrintWriter out ) {

--- a/src/main/java/org/deegree/maven/PortnumberMojo.java
+++ b/src/main/java/org/deegree/maven/PortnumberMojo.java
@@ -55,7 +55,7 @@ import org.apache.maven.project.MavenProject;
  * @version $Revision$, $Date$
  */
 @Execute(goal = "generate-portnumber", phase = LifecyclePhase.INITIALIZE)
-@Mojo(name = "generate-portnumber")
+@Mojo(name = "generate-portnumber", defaultPhase = LifecyclePhase.INITIALIZE)
 public class PortnumberMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)

--- a/src/main/java/org/deegree/maven/ServiceIntegrationTestMojo.java
+++ b/src/main/java/org/deegree/maven/ServiceIntegrationTestMojo.java
@@ -55,7 +55,7 @@ import org.deegree.maven.ithelper.ServiceIntegrationTestHelper;
  * @version $Revision$, $Date$
  */
 @Execute(goal = "test-services", phase = LifecyclePhase.INTEGRATION_TEST)
-@Mojo(name = "test-services")
+@Mojo(name = "test-services", defaultPhase = LifecyclePhase.INTEGRATION_TEST)
 public class ServiceIntegrationTestMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)

--- a/src/main/java/org/deegree/maven/WorkspaceITMojo.java
+++ b/src/main/java/org/deegree/maven/WorkspaceITMojo.java
@@ -47,6 +47,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.FileEntity;
 import org.apache.http.util.EntityUtils;
 import org.apache.maven.artifact.Artifact;
@@ -111,7 +112,7 @@ public class WorkspaceITMojo extends AbstractMojo {
 
                 getLog().info( "Sending against: " + url );
                 HttpPost post = new HttpPost( url );
-                post.setEntity( new FileEntity( file, null ) );
+                post.setEntity( new FileEntity( file, (ContentType) null ) );
                 resp = client.execute( post );
                 response = EntityUtils.toString( resp.getEntity() ).trim();
                 getLog().info( "Response after uploading was: " + response );

--- a/src/main/java/org/deegree/maven/WorkspaceITMojo.java
+++ b/src/main/java/org/deegree/maven/WorkspaceITMojo.java
@@ -69,7 +69,7 @@ import org.deegree.maven.utils.HttpUtils;
  * @version $Revision$, $Date$
  */
 @Execute(goal = "test-workspaces", phase = LifecyclePhase.INTEGRATION_TEST)
-@Mojo(name = "test-workspaces")
+@Mojo(name = "test-workspaces", defaultPhase = LifecyclePhase.INTEGRATION_TEST)
 public class WorkspaceITMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)

--- a/src/main/java/org/deegree/maven/WorkspaceInplaceMojo.java
+++ b/src/main/java/org/deegree/maven/WorkspaceInplaceMojo.java
@@ -76,7 +76,7 @@ public class WorkspaceInplaceMojo extends AbstractMojo {
     @Component
     private RepositorySystem repositorySystem;
 
-    @Parameter(name = "localRepository")
+    @Parameter(defaultValue = "${localRepository}")
     private ArtifactRepository localRepository;
 
     /**
@@ -101,6 +101,10 @@ public class WorkspaceInplaceMojo extends AbstractMojo {
 
             for ( Object o : workspaces ) {
                 Artifact a = (Artifact) o;
+                if ( a.getArtifactId().equals( project.getArtifactId() )
+                     && a.getGroupId().equals( project.getArtifactId() ) ) {
+                    continue;
+                }
                 log.info( "Unpacking workspace " + a.getArtifactId() );
                 FileInputStream in = new FileInputStream( a.getFile() );
                 try {

--- a/src/main/java/org/deegree/maven/WorkspaceInplaceMojo.java
+++ b/src/main/java/org/deegree/maven/WorkspaceInplaceMojo.java
@@ -64,7 +64,7 @@ import org.apache.maven.repository.RepositorySystem;
  * @version $Revision$, $Date$
  */
 @Execute(goal = "workspace-inplace", phase = LifecyclePhase.GENERATE_RESOURCES)
-@Mojo(name = "workspace-inplace")
+@Mojo(name = "workspace-inplace", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public class WorkspaceInplaceMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)

--- a/src/main/java/org/deegree/maven/WorkspaceMojo.java
+++ b/src/main/java/org/deegree/maven/WorkspaceMojo.java
@@ -69,7 +69,7 @@ import org.deegree.maven.utils.ZipUtils;
  * @version $Revision$, $Date$
  */
 @Execute(goal = "attach-workspace", phase = LifecyclePhase.PACKAGE)
-@Mojo(name = "attach-workspace")
+@Mojo(name = "attach-workspace", defaultPhase = LifecyclePhase.PACKAGE)
 public class WorkspaceMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)

--- a/src/main/java/org/deegree/maven/WorkspaceMojo.java
+++ b/src/main/java/org/deegree/maven/WorkspaceMojo.java
@@ -82,7 +82,7 @@ public class WorkspaceMojo extends AbstractMojo {
     @Component
     private RepositorySystem repositorySystem;
 
-    @Parameter(property = "localRepository")
+    @Parameter(defaultValue = "${localRepository}")
     private ArtifactRepository localRepository;
 
     @Component

--- a/src/main/java/org/deegree/maven/WorkspaceMojo.java
+++ b/src/main/java/org/deegree/maven/WorkspaceMojo.java
@@ -102,7 +102,12 @@ public class WorkspaceMojo extends AbstractMojo {
                                                        "deegree-workspace", true );
             List<Artifact> workspaces = new ArrayList<>();
             for ( Object o : artifacts ) {
-                workspaces.add( (Artifact) o );
+                Artifact a = (Artifact) o;
+                if ( project.getArtifactId().equals( a.getArtifactId() )
+                     && project.getGroupId().equals( a.getGroupId() ) ) {
+                    continue;
+                }
+                workspaces.add( a );
             }
             reverse( workspaces );
 
@@ -139,7 +144,7 @@ public class WorkspaceMojo extends AbstractMojo {
         log.info( "Attaching " + workspaceFile );
         Artifact artifact = project.getArtifact();
         if ( artifact.getType() == null || !artifact.getType().equals( "deegree-workspace" ) ) {
-            projectHelper.attachArtifact( project, "deegreeworkspace", workspaceFile );
+            projectHelper.attachArtifact( project, "deegree-workspace", workspaceFile );
         }
 
         artifact.setFile( workspaceFile );

--- a/src/main/java/org/deegree/maven/XMLCatalogueMojo.java
+++ b/src/main/java/org/deegree/maven/XMLCatalogueMojo.java
@@ -68,7 +68,7 @@ import com.google.common.base.Predicate;
  * @version $Revision: 31419 $, $Date: 2011-08-02 17:42:17 +0200 (Tue, 02 Aug 2011) $
  */
 @Execute(goal = "generate-jaxb-catalog", phase = LifecyclePhase.GENERATE_RESOURCES)
-@Mojo(name = "generate-jaxb-catalog")
+@Mojo(name = "generate-jaxb-catalog", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public class XMLCatalogueMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)

--- a/src/main/java/org/deegree/maven/XMLCatalogueMojo.java
+++ b/src/main/java/org/deegree/maven/XMLCatalogueMojo.java
@@ -80,7 +80,7 @@ public class XMLCatalogueMojo extends AbstractMojo {
     @Component
     private RepositorySystem repositorySystem;
 
-    @Parameter(name = "localRepository")
+    @Parameter(defaultValue = "${localRepository}")
     private ArtifactRepository localRepository;
 
     @Override

--- a/src/main/java/org/deegree/maven/ithelper/ServiceIntegrationTestHelper.java
+++ b/src/main/java/org/deegree/maven/ithelper/ServiceIntegrationTestHelper.java
@@ -107,7 +107,9 @@ public class ServiceIntegrationTestHelper {
             String input = IOUtils.toString( new URL( address ).openStream(), "UTF-8" );
             XMLInputFactory fac = XMLInputFactory.newInstance();
             XMLStreamReader in = fac.createXMLStreamReader( new StringReader( input ) );
-            in.next();
+            while (!in.isStartElement()) {
+                in.next();
+            }
             if ( in.getLocalName().toLowerCase().contains( "exception" ) ) {
                 log.error( "Actual response was:" );
                 log.error( input );

--- a/src/main/java/org/deegree/maven/utils/ClasspathHelper.java
+++ b/src/main/java/org/deegree/maven/utils/ClasspathHelper.java
@@ -95,7 +95,7 @@ public class ClasspathHelper {
             return result.getArtifacts();
         }
 
-        LinkedHashSet<Artifact> set = new LinkedHashSet<Artifact>();
+        LinkedHashSet<Artifact> set = new LinkedHashSet<>();
         if ( mainArtifact.getType() != null && mainArtifact.getType().equals( type ) ) {
             set.add( mainArtifact );
         }

--- a/src/main/java/org/deegree/maven/utils/ClasspathHelper.java
+++ b/src/main/java/org/deegree/maven/utils/ClasspathHelper.java
@@ -35,15 +35,8 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.maven.utils;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
-import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.repository.RepositorySystem;
+import static java.lang.Thread.currentThread;
+import static java.security.AccessController.doPrivileged;
 
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -54,8 +47,15 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.lang.Thread.currentThread;
-import static java.security.AccessController.doPrivileged;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.RepositorySystem;
 
 /**
  * 
@@ -100,8 +100,11 @@ public class ClasspathHelper {
             set.add( mainArtifact );
         }
         set.addAll( artifacts );
+        Set<Artifact> collected = set.stream()
+                .filter(dep -> dep.getType().equals(type))
+                .collect(Collectors.toSet());
 
-        return set;
+        return collected;
     }
 
     private static Set<?> resolveDeps( MavenProject project, ArtifactResolver artifactResolver,

--- a/src/main/java/org/deegree/maven/utils/HttpUtils.java
+++ b/src/main/java/org/deegree/maven/utils/HttpUtils.java
@@ -47,10 +47,16 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.ConnectionConfig;
+import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.protocol.BasicHttpContext;
 import org.deegree.maven.ithelper.ServiceIntegrationTestHelper;
@@ -66,11 +72,11 @@ import org.deegree.maven.ithelper.ServiceIntegrationTestHelper;
 public class HttpUtils {
 
     public static HttpClient getAuthenticatedHttpClient( ServiceIntegrationTestHelper helper ) {
-        DefaultHttpClient client = new DefaultHttpClient();
-        HttpConnectionParams.setConnectionTimeout( client.getParams(), 30000 );
-        HttpConnectionParams.setSoTimeout( client.getParams(), 1200000 );
-        client.getCredentialsProvider().setCredentials( AuthScope.ANY,
-                                                        new UsernamePasswordCredentials( "deegree", "deegree" ) );
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        CredentialsProvider creds = new BasicCredentialsProvider();
+        creds.setCredentials( AuthScope.ANY, new UsernamePasswordCredentials( "deegree", "deegree" ) );
+        builder.setDefaultCredentialsProvider( creds );
+        HttpClient client = builder.build();
         // preemptive authentication used to be easier in pre-4.x httpclient
         AuthCache authCache = new BasicAuthCache();
         BasicScheme basicAuth = new BasicScheme();

--- a/src/main/java/org/deegree/maven/utils/ZipUtils.java
+++ b/src/main/java/org/deegree/maven/utils/ZipUtils.java
@@ -82,7 +82,8 @@ public class ZipUtils {
         }
     }
 
-    public static void zipJarDependencies( Set<?> jarDeps, Log log, HashSet<String> visitedFiles, ZipOutputStream out ) {
+    public static void zipJarDependencies( Set<?> jarDeps, Log log, HashSet<String> visitedFiles,
+                                           ZipOutputStream out ) {
         for ( Object o : jarDeps ) {
             Artifact a = (Artifact) o;
             if ( a.getScope() == null || a.getScope().equalsIgnoreCase( "runtime" )
@@ -110,6 +111,10 @@ public class ZipUtils {
         for ( Artifact a : workspaces ) {
             log.info( "Processing files in dependency " + a.getArtifactId() );
             File tmp = new File( target, a.getArtifactId() );
+            if ( !a.getFile().exists() ) {
+                // happens if the main artifact has not been built yet
+                continue;
+            }
             FileInputStream in = new FileInputStream( a.getFile() );
             try {
                 unzip( in, tmp );


### PR DESCRIPTION
Looks like the `phase` attribute of the `@Execution` annotation is not sufficient any more to enable the user to omit the `<phase>` tag from his execution. This adds the `defaultPhase` attribute to all applicable `@Mojo` annotations.

Also fixes some issues with an obsolete httpclient version and bumps dependency versions once again.

Also fixes an override of jaxen classes by transitive dom4j dependency.

Also fixes the reference to the local repository for some mojos.

Also fixes dependency collection of certain types.